### PR TITLE
AVOCADO_LEAVES: Register as LeavesBlock instead of PillarBlock

### DIFF
--- a/src/main/java/dev/sterner/culturaldelights/common/registry/CDObjects.java
+++ b/src/main/java/dev/sterner/culturaldelights/common/registry/CDObjects.java
@@ -14,6 +14,7 @@ import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
 import net.fabricmc.fabric.api.registry.FuelRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.LeavesBlock;
 import net.minecraft.block.PillarBlock;
 import net.minecraft.block.SaplingBlock;
 import net.minecraft.item.AliasedBlockItem;
@@ -90,7 +91,7 @@ public class CDObjects {
 
     public static final Block AVOCADO_LOG = register("avocado_log", new PillarBlock(FabricBlockSettings.copy(Blocks.JUNGLE_LOG)), settings(), true);
     public static final Block AVOCADO_WOOD = register("avocado_wood", new PillarBlock(FabricBlockSettings.copy(Blocks.JUNGLE_WOOD)), settings(), true);
-    public static final Block AVOCADO_LEAVES = register("avocado_leaves", new PillarBlock(FabricBlockSettings.copy(Blocks.JUNGLE_LEAVES)), settings(), true);
+    public static final Block AVOCADO_LEAVES = register("avocado_leaves", new LeavesBlock(FabricBlockSettings.copy(Blocks.JUNGLE_LEAVES)), settings(), true);
 
     public static final Block AVOCADO_SAPLING = register("avocado_sapling", new SaplingBlock(new AvocadoSaplingGenerator(), FabricBlockSettings.copy(Blocks.OAK_SAPLING)), settings(), true);
 


### PR DESCRIPTION
PillarBlock is for blocks like Logs, Basalt, and Quartz Pillars. LeavesBlock is for Leaves, and includes the necessary methods for naturally decaying.